### PR TITLE
Fix navigation flag null cast

### DIFF
--- a/src/DevToolbox.WinUI/Services/NavigationService.cs
+++ b/src/DevToolbox.WinUI/Services/NavigationService.cs
@@ -183,7 +183,7 @@ public class NavigationService : INavigationService
         if (_frame is null)
             return;
 
-        var clearNavigation = (bool)_frame.Tag;
+        var clearNavigation = _frame.Tag is bool flag && flag;
         if (clearNavigation)
         {
             _frame.BackStack.Clear();


### PR DESCRIPTION
## Summary
- avoid casting `Frame.Tag` when it may be null in WinUI navigation service

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c839d3ec832eae7b3faa723afad1