### PR TITLE
Fix UndoRedoStackItem ToString format

### DIFF
--- a/src/DevToolbox.Wpf/Data/UndoRedoStackItem.cs
+++ b/src/DevToolbox.Wpf/Data/UndoRedoStackItem.cs
@@ -38,7 +38,7 @@ internal class UndoRedoStackItem : IEquatable<UndoRedoStackItem>
 
     #region Overrides
 
-    public override string ToString() => string.Concat(_stringTemplate, Rect.X, Rect.X, Zoom);
+    public override string ToString() => string.Format(_stringTemplate, Rect.X, Rect.Y, Zoom);
 
     #endregion
 


### PR DESCRIPTION
## Summary
- fix `UndoRedoStackItem.ToString` to use `string.Format` with correct coordinates

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c839d3ec832eae7b3faa723afad1