### PR TITLE
Fix zoom save condition

### DIFF
--- a/src/DevToolbox.Wpf/Controls/ZoomAndPanControl.cs
+++ b/src/DevToolbox.Wpf/Controls/ZoomAndPanControl.cs
@@ -1021,7 +1021,7 @@ public class ZoomAndPanControl : ContentControl, IScrollInfo
     /// </summary>
     public void DelayedSaveZoom1500Miliseconds()
     {
-        if (!_timer1500Miliseconds?.Running != true) _viewportZoomCache = CreateUndoRedoStackItem();
+        if (_timer1500Miliseconds?.Running != true) _viewportZoomCache = CreateUndoRedoStackItem();
         (_timer1500Miliseconds ??= new KeepAliveTimer(TimeSpan.FromMilliseconds(1500), () =>
         {
             if (_viewportZoomCache is null || (_undoStack.Any() && _viewportZoomCache.Equals(_undoStack.Peek()))) return;


### PR DESCRIPTION
## Summary
- fix conditional logic in `DelayedSaveZoom1500Miliseconds` so zoom state is saved correctly

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cfb97698832eacd45e8d9ee337af