### PR TITLE
Fix row update bounds check

### DIFF
--- a/src/DevToolbox.Wpf/Controls/DocumentPanel.cs
+++ b/src/DevToolbox.Wpf/Controls/DocumentPanel.cs
@@ -116,7 +116,7 @@ public class DocumentPanel : Grid, ILayoutSerializable
     {
         if (VisualTreeHelper.GetParent(child) is not DocumentPanel grid) return;
         var row = GetRow((UIElement)child);
-        if (row >= grid.ColumnDefinitions.Count) return;
+        if (row >= grid.RowDefinitions.Count) return;
         grid.Dispatcher.BeginInvoke(new Action(() => updateAction(grid.RowDefinitions[row])));
     }
 


### PR DESCRIPTION
## Summary
- correct `DocumentPanel` row update check to use RowDefinitions

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862d223d3a0832e8ff29cbebd72e60a